### PR TITLE
Fix the dye recipes for square glass.

### DIFF
--- a/glass.lua
+++ b/glass.lua
@@ -279,7 +279,7 @@ if minetest.get_modpath("unifieddyes") then
 	type = "shapeless",
 	neutral_node = "",
 	recipe = {
-			 "darkage:stained_milk_glass_square",
+			 "darkage:milk_glass_square",
 			 "MAIN_DYE"
 		}
 	})


### PR DESCRIPTION
The dye recipes for the milky square glass were broken due to a subtle oversight, this fixes it.