### PR TITLE
fix unified_dyes integration

### DIFF
--- a/glass.lua
+++ b/glass.lua
@@ -15,7 +15,7 @@ minetest.register_node("darkage:glass", {
 	use_texture_alpha = "clip",
 	paramtype = "light",
 	sunlight_propagates = true,
-	groups = {cracky = 3, oddly_breakable_by_hand = 3, not_cuttable=1},
+	groups = {cracky = 3, oddly_breakable_by_hand = 3, not_cuttable = 1},
 	sounds = default.node_sound_glass_defaults(),
 })
 
@@ -28,32 +28,15 @@ minetest.register_craft({
 	}
 })
 
---[[ Round Glass By Semmett9 aka Infinatum ]]
-if minetest.get_modpath("unifieddyes") then
-	minetest.register_node("darkage:milk_glass", {
-		description = "Milky Medieval Glass (Good for colorization)",
-		drawtype = "glasslike",
-		tiles = {"darkage_milk_glass.png"},
-		use_texture_alpha=true,
-		paramtype = "light",
-		paramtype2 = "color",
-		palette = "unifieddyes_palette_extended.png",
-		sunlight_propagates = true,
-		groups = {cracky = 3, oddly_breakable_by_hand = 3, not_cuttable=1, ud_param2_colorable = 1},
-		sounds = default.node_sound_glass_defaults(),
-		after_dig_node = unifieddyes.after_dig_node
-	})
-end
-
 minetest.register_node("darkage:glass_round", {
 	description = "Round Glass",
 	drawtype = "glasslike",
-	tiles = { "darkage_glass_round.png" },
+	tiles = {"darkage_glass_round.png"},
 	paramtype = "light",
 	use_texture_alpha = "clip",
 	sunlight_propagates = true,
 	sounds = default.node_sound_glass_defaults(),
-	groups = {cracky=3,oddly_breakable_by_hand=3, not_cuttable=1},
+	groups = {cracky = 3, oddly_breakable_by_hand = 3, not_cuttable = 1},
 })
 
 minetest.register_craft({
@@ -70,20 +53,20 @@ minetest.register_craft({
 minetest.register_node("darkage:glass_square", {
 	description = "Square Glass",
 	drawtype = "glasslike",
-	tiles = { "darkage_glass_square.png" },
+	tiles = {"darkage_glass_square.png"},
 	paramtype = "light",
 	use_texture_alpha = "clip",
 	sunlight_propagates = true,
 	sounds = default.node_sound_glass_defaults(),
-	groups = {cracky=3,oddly_breakable_by_hand=3, not_cuttable=1},
+	groups = {cracky = 3, oddly_breakable_by_hand = 3, not_cuttable = 1},
 })
 
 minetest.register_craft({
 	output = "darkage:glass_square 8",
 	recipe = {
-		{"default:glass",		"default:steel_ingot", "default:glass"},
+		{"default:glass", "default:steel_ingot", "default:glass"},
 		{"default:steel_ingot", "default:steel_ingot", "default:steel_ingot"},
-		{"default:glass",		"default:steel_ingot", "default:glass"},
+		{"default:glass", "default:steel_ingot", "default:glass"},
 	}
 })
 
@@ -101,15 +84,15 @@ minetest.register_node("darkage:glow_glass", {
 	use_texture_alpha = "clip",
 	paramtype = "light",
 	sunlight_propagates = true,
-	light_source = default.LIGHT_MAX-3,
-	groups = {cracky = 3, oddly_breakable_by_hand = 3, not_cuttable=1},
+	light_source = default.LIGHT_MAX - 3,
+	groups = {cracky = 3, oddly_breakable_by_hand = 3, not_cuttable = 1},
 	sounds = default.node_sound_glass_defaults(),
-    inventory_image = minetest.inventorycube("darkage_glow_glass.png")
+	inventory_image = minetest.inventorycube("darkage_glow_glass.png")
 })
 
 minetest.register_craft({
 	output = "darkage:glow_glass 1",
-    type = "shaped",
+	type = "shaped",
 	recipe = {
 		{"darkage:glass"},
 		{"default:torch"}
@@ -119,7 +102,7 @@ minetest.register_craft({
 -- Recycling
 minetest.register_craft({
 	output = "darkage:glass 1",
-    type = "shaped",
+	type = "shaped",
 	recipe = {{"darkage:glow_glass"}},
 })
 
@@ -132,18 +115,18 @@ minetest.register_node("darkage:glow_glass_round", {
 	use_texture_alpha = "clip",
 	paramtype = "light",
 	sunlight_propagates = true,
-	light_source = default.LIGHT_MAX-3,
-	groups = {cracky = 3, oddly_breakable_by_hand = 3, not_cuttable=1},
+	light_source = default.LIGHT_MAX - 3,
+	groups = {cracky = 3, oddly_breakable_by_hand = 3, not_cuttable = 1},
 	sounds = default.node_sound_glass_defaults(),
-    inventory_image = minetest.inventorycube("darkage_glow_glass_round.png")
+	inventory_image = minetest.inventorycube("darkage_glow_glass_round.png")
 })
 
 minetest.register_craft({
 	output = "darkage:glow_glass_round 1",
-    type = "shaped",
+	type = "shaped",
 	recipe = {
 		{"darkage:glass_round"},
-        {"default:torch"}
+		{"default:torch"}
 	}
 })
 
@@ -156,31 +139,31 @@ minetest.register_craft({
 --]] Square Glow Glass ]]
 
 minetest.register_node("darkage:glow_glass_square", {
-    description = "Medieval Square Glow Glass",
-    drawtype = "glasslike",
-    tiles = {"darkage_glass_square.png"},
+	description = "Medieval Square Glow Glass",
+	drawtype = "glasslike",
+	tiles = {"darkage_glass_square.png"},
 	use_texture_alpha = "clip",
 	paramtype = "light",
 	sunlight_propagates = true,
-	light_source = default.LIGHT_MAX-3,
-	groups = {cracky = 3, oddly_breakable_by_hand = 3, not_cuttable=1},
+	light_source = default.LIGHT_MAX - 3,
+	groups = {cracky = 3, oddly_breakable_by_hand = 3, not_cuttable = 1},
 	sounds = default.node_sound_glass_defaults(),
-    inventory_image = minetest.inventorycube("darkage_glow_glass_square.png")
+	inventory_image = minetest.inventorycube("darkage_glow_glass_square.png")
 })
 
 minetest.register_craft({
-    output = "darkage:glow_glass_square 1",
-    type = "shaped",
-    recipe = {
-        {"darkage:glass_square"},
-        {"default:torch"},
-    }
+	output = "darkage:glow_glass_square 1",
+	type = "shaped",
+	recipe = {
+		{"darkage:glass_square"},
+		{"default:torch"},
+	}
 })
 
 --Recycling
 minetest.register_craft({
-    output = "darkage:glass_square 1",
-    recipe = {{"darkage:glow_glass_square"}}
+	output = "darkage:glass_square 1",
+	recipe = {{"darkage:glow_glass_square"}}
 })
 
 --[[
@@ -201,28 +184,22 @@ if minetest.get_modpath("unifieddyes") then
 		paramtype2 = "color",
 		palette = "unifieddyes_palette_extended.png",
 		sunlight_propagates = true,
-		groups = {cracky = 3, oddly_breakable_by_hand = 3, not_cuttable=1, ud_param2_colorable = 1},
+		groups = {cracky = 3, oddly_breakable_by_hand = 3, not_cuttable = 1, ud_param2_colorable = 1},
 		sounds = default.node_sound_glass_defaults()
 	})
 
-	minetest.register_craft({
+	unifieddyes.register_color_craft({
 		output = "darkage:milk_glass",
+		palette = "extended",
 		type = "shapeless",
-		recipe = {"darkage:glass", "dye:white"}
+		neutral_node = "darkage:glass",
+		recipe = {
+			"NEUTRAL_NODE",
+			"MAIN_DYE"
+		}
 	})
 
-    unifieddyes.register_color_craft({
-        output = "darkage:milk_glass",
-        palette = "extended",
-        type = "shapeless",
-        neutral_node = "",
-        recipe = {
-                 "darkage:milk_glass",
-                 "MAIN_DYE"
-        }
-    })
-
-    -- Recycling
+	-- Recycling
 	minetest.register_craft({
 		output = "darkage:glass 1",
 		recipe = {{"darkage:milk_glass"}}
@@ -239,26 +216,20 @@ if minetest.get_modpath("unifieddyes") then
 		paramtype2 = "color",
 		palette = "unifieddyes_palette_extended.png",
 		sunlight_propagates = true,
-		groups = {cracky = 3, oddly_breakable_by_hand = 3, not_cuttable=1, ud_param2_colorable = 1},
+		groups = {cracky = 3, oddly_breakable_by_hand = 3, not_cuttable = 1, ud_param2_colorable = 1},
 		sounds = default.node_sound_glass_defaults()
 	})
-	-- Craft
-	minetest.register_craft({
-		output = "darkage:milk_glass_round",
-		type = "shapeless",
-		recipe = {"darkage:glass_round", "dye:white"},
-	})
 
-    unifieddyes.register_color_craft({
-        output = "darkage:milk_glass_round",
-        palette = "extended",
-        type = "shapeless",
-        neutral_node = "",
-        recipe = {
-                 "darkage:milk_glass_round",
-                 "MAIN_DYE"
-        }
-    })
+	unifieddyes.register_color_craft({
+		output = "darkage:milk_glass_round",
+		palette = "extended",
+		type = "shapeless",
+		neutral_node = "darkage:glass_round",
+		recipe = {
+			"NEUTRAL_NODE",
+			"MAIN_DYE"
+		}
+	})
 
 	-- Recycling
 	minetest.register_craft({
@@ -277,7 +248,7 @@ if minetest.get_modpath("unifieddyes") then
 		paramtype2 = "color",
 		palette = "unifieddyes_palette_extended.png",
 		sunlight_propagates = true,
-		groups = {cracky = 3, oddly_breakable_by_hand = 3, not_cuttable=1, ud_param2_colorable = 1},
+		groups = {cracky = 3, oddly_breakable_by_hand = 3, not_cuttable = 1, ud_param2_colorable = 1},
 		sounds = default.node_sound_glass_defaults()
 	})
 
@@ -289,13 +260,13 @@ if minetest.get_modpath("unifieddyes") then
 	})
 
 	unifieddyes.register_color_craft({
-	output = "darkage:milk_glass_square",
-	palette = "extended",
-	type = "shapeless",
-	neutral_node = "",
-	recipe = {
-			 "darkage:milk_glass_square",
-			 "MAIN_DYE"
+		output = "darkage:milk_glass_square",
+		palette = "extended",
+		type = "shapeless",
+		neutral_node = "darkage:glass_square",
+		recipe = {
+			"NEUTRAL_NODE",
+			"MAIN_DYE"
 		}
 	})
 


### PR DESCRIPTION
currently, if you craft milky glass, place it, and break it, it will not stack w/ any that haven't been placed.

this fixes that by ensuring that the crafted variety has the same metadata as the default color.

this does *not* fix any milky glass that has already been crafted; fixing that would require a way to override the contents of every inventory, which is beyond the scope of this issue. 